### PR TITLE
Make settings window resizable

### DIFF
--- a/OpenSky.Agent/Views/Settings.xaml
+++ b/OpenSky.Agent/Views/Settings.xaml
@@ -20,7 +20,7 @@
                 xmlns:converters="clr-namespace:OpenSky.Agent.Converters"
                 mc:Ignorable="d"
                 Title="Settings" Width="900" LoadingText="{Binding LoadingText}" Loaded="SettingsOnLoaded"
-                SizeToContent="Height" ShowMinMaxButtons="False" ResizeMode="NoResize" HorizontalScrollBar="False">
+                SizeToContent="Height" ShowMinMaxButtons="False" ResizeMode="CanResize" HorizontalScrollBar="False">
     <Window.DataContext>
         <models:SettingsViewModel />
     </Window.DataContext>


### PR DESCRIPTION
**Issue:**
Settings window clips out of 1920x1080 screen, stopping me from saving my settings.

**Solution:**
Make the window resizable

**Example before solution:**
![image](https://github.com/opensky-to/agent/assets/65853224/2633c7fa-b634-411a-8c8b-c804487f9ac7)